### PR TITLE
Adding of a k8s manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ credentials/*
 .DS_Store
 vendor
 .env
+used-manifest.k8s.yml
 
 # Binaries for programs and plugins
 *.exe

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-FROM golang:1.9 AS build
-WORKDIR /go/src/ecr_reverse_proxy/
+FROM golang:1.11 AS build
 RUN apt-get update && apt-get install unzip
 RUN cd /tmp && wget -L https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 && mv dep-linux-amd64 dep && chmod +x dep
-COPY Gopkg.* /go/src/ecr_reverse_proxy/
+WORKDIR /go/src/github.com/marjamis/ecr_reverse_proxy/
+COPY Gopkg.* ./
 RUN /tmp/dep ensure --vendor-only
-COPY *.go /go/src/ecr_reverse_proxy/
+COPY *.go ./
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o ecr_reverse_proxy .
 
-FROM alpine:latest
+FROM alpine:3.8
 LABEL maintainer=marjamis
 RUN apk --no-cache add ca-certificates && mkdir /.ecr/ && chown nobody:nobody /.ecr/
 USER nobody
 WORKDIR /app/
-COPY --from=build /go/src/ecr_reverse_proxy/ecr_reverse_proxy .
+COPY --from=build /go/src/github.com/marjamis/ecr_reverse_proxy .
 ENTRYPOINT ["./ecr_reverse_proxy"]

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,11 @@ build:
 
 run: checks
 	TLS_CERTIFICATE=$(TLS_CERTIFICATE) TLS_PRIVATE_KEY=$(TLS_PRIVATE_KEY) REGION=$(REGION) REGISTRY=$(REGISTRY) ECR_REGISTRY=$(ECR_REGISTRY) PORT=$(PORT) go run main.go
+
+# Replaces variables in the generic k8s manifest for internal testing
+k8s-manifestReplace:
+	cat manifest.k8s.yml | sed -f .env > used-manifest.k8s.yml
+
+# Generates and adds the TLS secrets for the Ingress Controller to use
+k8s-addSecrets: genSelfsigned
+	kubectl create secret tls ecrreverseproxy --cert ./credentials/cert.pem --key ./credentials/privkey.pem

--- a/manifest.k8s.yml
+++ b/manifest.k8s.yml
@@ -1,0 +1,86 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ecrreverseproxy
+data:
+  PORT: "{PORT}"
+  REGION: {REGION}
+  REGISTRY: {REGISTRY}
+  ECR_REGISTRY: {ECR_REGISTRY}
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: ecrreverseproxy
+  name: ecrreverseproxy
+  namespace: kube-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ecrreverseproxy
+  template:
+    metadata:
+      labels:
+        app: ecrreverseproxy
+    spec:
+      containers:
+        - image: marjamis/ecr_reverse_proxy:latest
+          name: ecrreverseproxy
+          ports:
+          - containerPort: {PORT}
+            protocol: TCP
+          envFrom:
+          - configMapRef:
+              name: ecrreverseproxy
+      volumes:
+        - name: certs
+          secret:
+            secretName: ecrreverseproxy
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: ecrreverseproxy
+  name: ecrreverseproxy
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "0.0.0.0/0"
+  namespace: kube-system
+spec:
+  type: LoadBalancer
+  ports:
+  - name: http
+    port: 443
+    targetPort: {PORT}
+    protocol: TCP
+  selector:
+    app: ecrreverseproxy
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ecrreverseproxy
+  namespace: kube-system
+  annotations:
+    nginx.ingress.kubernetes.io/ssl-redirect: true
+    nginx.ingress.kubernetes.io/force-ssl-redirect: true
+spec:
+  rules:
+  - host: {HOST}
+    http:
+      paths:
+      - backend:
+          serviceName: ecrreverseproxy
+          servicePort: {PORT}
+        path: /
+  tls:
+    - hosts:
+      - {HOST}
+      secretName: ecrreverseproxy


### PR DESCRIPTION
A generic k8s manifest has been added to allow the ecr_reverse_proxy to be used within a k8s cluster which will resolve #2.
